### PR TITLE
feat: add --output-path argument for directory-only output

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ pip install requests PyPDF2
 ### Command Line Interface
 
 ```bash
-python -m openrouter.openrouter_client --input <input_file> --config <config_file> [--output <output_file>]
+python -m openrouter.openrouter_client \\
+  --input <input_file> \\
+  --config <config_file> \\
+  [--output <output_file>] \\
+  [--output-path <output_directory>] \\
+  [--debug Y/N]
 ```
 
 ### Programmatic Usage
@@ -71,7 +76,11 @@ See `example_usage.py` for a complete example.
 
 - `--input`: Path to the input file (image, PDF, or text) or a URL to an image/PDF
 - `--config`: Path to the configuration file
-- `--output`: (Optional) Path to the output file. If not provided, a default name will be generated based on the model name and input filename
+- `--output`: (Optional) Full path to the output file including filename (mutually exclusive with --output-path)
+- `--output-path`: (Optional) Directory path where output file should be saved (uses auto-generated filename, mutually exclusive with --output)
+- `--debug`: (Optional) Include prompts in output file (Y/N, default: N)
+
+Note: Only one of --output or --output-path may be used at a time
 
 ### Examples
 

--- a/openrouter_client.py
+++ b/openrouter_client.py
@@ -26,7 +26,9 @@ def main():
     parser = argparse.ArgumentParser(description="Process files through the OpenRouter API")
     parser.add_argument("--input", required=True, help="Path to input file (image, PDF, or text)")
     parser.add_argument("--config", required=True, help="Path to configuration file")
-    parser.add_argument("--output", help="Path to output file (optional)")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--output", help="Complete output file path including filename")
+    output_group.add_argument("--output-path", help="Directory path for output (uses auto-generated filename)")
     parser.add_argument("--debug", help="Include prompts in output file (Y/N)", default="N")
     args = parser.parse_args()
     
@@ -46,9 +48,15 @@ def main():
     # Determine input type
     input_type = determine_input_type(args.input)
     
-    # Generate default output filename if not provided
-    output_file = args.output
-    if not output_file:
+    # Handle output file path
+    if args.output_path:
+        # Use specified directory with auto-generated filename
+        output_file = os.path.join(args.output_path, generate_default_output_filename(args.input, config["MODEL"]))
+    elif args.output:
+        # Use specified full output path
+        output_file = args.output
+    else:
+        # Default behavior - auto-generated filename in current directory
         output_file = generate_default_output_filename(args.input, config["MODEL"])
     
     # Process the input file based on its type


### PR DESCRIPTION
## Description
Adds `--output-path` argument for directory-only output specification

Resolves #1

## Changes
- Added mutually exclusive argument group
- Implemented directory path handling
- Updated documentation in README.md

## Testing
Verified all scenarios:
1. `--output-path` saves to specified directory
2. `--output` still works with full path
3. Default behavior unchanged